### PR TITLE
Fix statistic output

### DIFF
--- a/sc_hw_metrics.h
+++ b/sc_hw_metrics.h
@@ -209,7 +209,7 @@ namespace sc_hw_metrics {
             }
         }
 
-        ~asil() {
+        void end_of_simulation() override {
             std::cout << "RES:  " << residual   << std::endl;
             std::cout << "LAT:  " << latent     << std::endl;
             std::cout << "SPFM: " << spfm       << "%" << std::endl;


### PR DESCRIPTION
The output of the SystemC signals is not possible because the SystemC data might not exist at the time of the destructor call. Instead end_of_simulation is used. Thanks to @derchr for finding the bug!